### PR TITLE
Refactor liquidity source to support multiple LSP nodes

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -116,6 +116,7 @@ interface Builder {
 	void set_pathfinding_scores_source(string url);
 	void set_liquidity_source_lsps1(PublicKey node_id, SocketAddress address, string? token);
 	void set_liquidity_source_lsps2(PublicKey node_id, SocketAddress address, string? token);
+	void add_lsp(PublicKey node_id, SocketAddress address, string? token);
 	void set_storage_dir_path(string storage_dir_path);
 	void set_filesystem_logger(string? log_file_path, LogLevel? max_log_level);
 	void set_log_facade_logger();
@@ -298,6 +299,8 @@ interface UnifiedPayment {
 interface LSPS1Liquidity {
 	[Throws=NodeError]
 	LSPS1OrderStatus request_channel(u64 lsp_balance_sat, u64 client_balance_sat, u32 channel_expiry_blocks, boolean announce_channel);
+	[Throws=NodeError]
+	LSPS1OrderStatus request_channel_from_lsp(u64 lsp_balance_sat, u64 client_balance_sat, u32 channel_expiry_blocks, boolean announce_channel, PublicKey node_id);
 	[Throws=NodeError]
 	LSPS1OrderStatus check_order_status(LSPS1OrderId order_id);
 };

--- a/src/event.rs
+++ b/src/event.rs
@@ -1221,12 +1221,8 @@ where
 				let user_channel_id: u128 = rng().random();
 				let allow_0conf = self.config.trusted_peers_0conf.contains(&counterparty_node_id);
 				let mut channel_override_config = None;
-				if let Some((lsp_node_id, _)) = self
-					.liquidity_source
-					.as_ref()
-					.and_then(|ls| ls.as_ref().get_lsps2_lsp_details())
-				{
-					if lsp_node_id == counterparty_node_id {
+				if let Some(ls) = self.liquidity_source.as_ref() {
+					if ls.as_ref().is_lsps_node(&counterparty_node_id) {
 						// When we're an LSPS2 client, allow claiming underpaying HTLCs as the LSP will skim off some fee. We'll
 						// check that they don't take too much before claiming.
 						//

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -1743,7 +1743,7 @@ async fn do_lsps2_client_service_integration(client_trusts_lsp: bool) {
 	let client_config = random_config(true);
 	setup_builder!(client_builder, client_config.node_config);
 	client_builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
-	client_builder.set_liquidity_source_lsps2(service_node_id, service_addr, None);
+	client_builder.add_lsp(service_node_id, service_addr, None);
 	let client_node = client_builder.build(client_config.node_entropy.into()).unwrap();
 	client_node.start().unwrap();
 
@@ -2060,7 +2060,7 @@ async fn lsps2_client_trusts_lsp() {
 	let client_config = random_config(true);
 	setup_builder!(client_builder, client_config.node_config);
 	client_builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
-	client_builder.set_liquidity_source_lsps2(service_node_id, service_addr.clone(), None);
+	client_builder.add_lsp(service_node_id, service_addr.clone(), None);
 	let client_node = client_builder.build(client_config.node_entropy.into()).unwrap();
 	client_node.start().unwrap();
 	let client_node_id = client_node.node_id();
@@ -2235,7 +2235,7 @@ async fn lsps2_lsp_trusts_client_but_client_does_not_claim() {
 	let client_config = random_config(true);
 	setup_builder!(client_builder, client_config.node_config);
 	client_builder.set_chain_source_esplora(esplora_url.clone(), Some(sync_config));
-	client_builder.set_liquidity_source_lsps2(service_node_id, service_addr.clone(), None);
+	client_builder.add_lsp(service_node_id, service_addr.clone(), None);
 	let client_node = client_builder.build(client_config.node_entropy.into()).unwrap();
 	client_node.start().unwrap();
 


### PR DESCRIPTION
Replace per-protocol single-LSP configuration `LSPS1Client, LSPS2Client` with a unified `Vec<LspNode>` model where users configure LSP nodes via `add_lsp()` and protocol support is discovered at runtime via LSPS0 `list_protocols`.

- Replace separate `LSPS1Client/LSPS2Client` with global pending request maps keyed by `LSPSRequestId`
- Add LSPS0 protocol discovery `discover_lsp_protocols` with event handling for `ListProtocolsResponse`
- Update events to use is_lsps_node() for multi-LSP counterparty checks
- Deprecate `set_liquidity_source_lsps1/lsps2` builder methods in favor of `add_lsp()`
- Spawn background discovery task on `Node::start()`